### PR TITLE
feat: Add Series and Standalone Content Generation with Tone Support

### DIFF
--- a/api_client/gpt_client.py
+++ b/api_client/gpt_client.py
@@ -1,6 +1,6 @@
 import openai
 from openai import OpenAIError
-from config import OPENAI_API_KEY, MODEL_NAME, MAX_TOKENS, TEMPERATURE, BLOG_POST_STRUCTURE, VIDEO_SCRIPT_STRUCTURE, TOPICS
+from config import OPENAI_API_KEY, MODEL_NAME, MAX_TOKENS, TEMPERATURE, BLOG_POST_STRUCTURE, VIDEO_SCRIPT_STRUCTURE, TOPICS, IS_SERIES, SERIES_TITLE, SERIES_PART, EXAMPLE, TONE
 import os
 
 
@@ -17,18 +17,20 @@ class GPTClient:
             raise ValueError("OpenAI API key not found. Please set the 'OPENAI_API_KEY' in your .env file.")
         openai.api_key = OPENAI_API_KEY
 
+    def construct_prompt(self, base_prompt: str, topic: str, series_title: str = None, part: str = None) -> str:
+        """
+        Construct the prompt for the GPT model, including series information, tone, and examples if applicable.
+        """
+        prompt = f"{base_prompt} {topic} in a {TONE} tone."
+        if series_title and part:
+            prompt = f"{series_title} - {part}: {prompt}"
+        if EXAMPLE:
+            prompt += f" Please include this example: {EXAMPLE}"
+        return prompt
 
     def generate_section(self, prompt: str, max_tokens: int = MAX_TOKENS, temperature: float = TEMPERATURE) -> str:
         """
         Generate text for a specific section based on the provided prompt using the OpenAI GPT model.
-
-        Parameters:
-        - prompt (str): The prompt to send to the GPT model.
-        - max_tokens (int): The maximum number of tokens to generate. Default is from config.
-        - temperature (float): The sampling temperature. Default is from config.
-
-        Returns:
-        - str: The generated text from the GPT model.
         """
         try:
             response = openai.chat.completions.create(
@@ -47,45 +49,93 @@ class GPTClient:
     def generate_and_save_blog_posts(self, topics=TOPICS, output_dir="output/blog_posts"):
         """
         Generate complete blog posts for each topic in the topics list and save them to files.
-
-        Parameters:
-        - topics (list): List of topics to generate content for. Default is from config.
-        - output_dir (str): Directory to save the output files.
         """
         if not os.path.exists(output_dir):
             os.makedirs(output_dir, exist_ok=True)
 
-        for topic in topics:
-            sections = []
-            for section_name, section_prompt in BLOG_POST_STRUCTURE.items():
-                content = self.generate_section(section_prompt(topic))
-                sections.append(f"{section_name.capitalize()}:\n{content}\n")
-
-            # Save to file using os.path.join to handle paths
-            file_path = os.path.join(output_dir, f"{topic.replace(' ', '_')}.txt")
-            with open(file_path, "w", encoding="utf-8") as file:
-                file.write("\n".join(sections))
-            print(f"Blog post for '{topic}' saved to {file_path}")
+        if IS_SERIES:
+            self._generate_series_blog_posts(topics, output_dir)
+        else:
+            self._generate_standalone_blog_posts(topics, output_dir)
 
     def generate_and_save_video_scripts(self, topics=TOPICS, output_dir="output/video_scripts"):
         """
         Generate complete video scripts for each topic in the topics list and save them to files.
-
-        Parameters:
-        - topics (list): List of topics to generate content for. Default is from config.
-        - output_dir (str): Directory to save the output files.
         """
         if not os.path.exists(output_dir):
             os.makedirs(output_dir, exist_ok=True)
 
+        if IS_SERIES:
+            self._generate_series_video_scripts(topics, output_dir)
+        else:
+            self._generate_standalone_video_scripts(topics, output_dir)
+
+    def _generate_series_blog_posts(self, topics, output_dir):
+        """
+        Generate a series of blog posts, saving each one with the correct series title and part.
+        """
+        for i, topic in enumerate(topics):
+            series_title = SERIES_TITLE
+            part = SERIES_PART[i] if i < len(SERIES_PART) else f"Part {i + 1}"
+
+            sections = []
+            for section_name, section_prompt in BLOG_POST_STRUCTURE.items():
+                content = self.generate_section(self.construct_prompt(section_prompt, topic, series_title=series_title, part=part))
+                sections.append(f"{section_name.capitalize()}:\n{content}\n")
+
+            file_name = f"{topic.replace(' ', '_')}_part_{i + 1}.txt"
+            file_path = os.path.join(output_dir, file_name)
+            with open(file_path, "w", encoding="utf-8") as file:
+                file.write("\n".join(sections))
+            print(f"Blog post for '{topic}' in series '{series_title}' saved to {file_path}")
+
+    def _generate_standalone_blog_posts(self, topics, output_dir):
+        """
+        Generate standalone blog posts, saving each one individually.
+        """
+        for topic in topics:
+            sections = []
+            for section_name, section_prompt in BLOG_POST_STRUCTURE.items():
+                content = self.generate_section(self.construct_prompt(section_prompt, topic))
+                sections.append(f"{section_name.capitalize()}:\n{content}\n")
+
+            file_name = f"{topic.replace(' ', '_')}.txt"
+            file_path = os.path.join(output_dir, file_name)
+            with open(file_path, "w", encoding="utf-8") as file:
+                file.write("\n".join(sections))
+            print(f"Blog post for '{topic}' saved to {file_path}")
+
+    def _generate_series_video_scripts(self, topics, output_dir):
+        """
+        Generate a series of video scripts, saving each one with the correct series title and part.
+        """
+        for i, topic in enumerate(topics):
+            series_title = SERIES_TITLE
+            part = SERIES_PART[i] if i < len(SERIES_PART) else f"Part {i + 1}"
+
+            sections = []
+            for section_name, section_prompt in VIDEO_SCRIPT_STRUCTURE.items():
+                content = self.generate_section(self.construct_prompt(section_prompt, topic, series_title=series_title, part=part))
+                sections.append(f"{section_name.capitalize()}:\n{content}\n")
+
+            file_name = f"{topic.replace(' ', '_')}_script_part_{i + 1}.txt"
+            file_path = os.path.join(output_dir, file_name)
+            with open(file_path, "w", encoding="utf-8") as file:
+                file.write("\n".join(sections))
+            print(f"Video script for '{topic}' in series '{series_title}' saved to {file_path}")
+
+    def _generate_standalone_video_scripts(self, topics, output_dir):
+        """
+        Generate standalone video scripts, saving each one individually.
+        """
         for topic in topics:
             sections = []
             for section_name, section_prompt in VIDEO_SCRIPT_STRUCTURE.items():
-                content = self.generate_section(section_prompt(topic))
+                content = self.generate_section(self.construct_prompt(section_prompt, topic))
                 sections.append(f"{section_name.capitalize()}:\n{content}\n")
 
-            # Save to file using os.path.join to handle paths
-            file_path = os.path.join(output_dir, f"{topic.replace(' ', '_')}_script.txt")
+            file_name = f"{topic.replace(' ', '_')}_script.txt"
+            file_path = os.path.join(output_dir, file_name)
             with open(file_path, "w", encoding="utf-8") as file:
                 file.write("\n".join(sections))
             print(f"Video script for '{topic}' saved to {file_path}")

--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ MAX_TOKENS = 2000
 TEMPERATURE = 0.2
 
 # Other imports and configurations
-TOPICS = ["Introduction to ANOVA", "Advanced ANOVA"]
+TOPICS = ["Introduction to ANOVA", "Types of ANOVA", "ANOVA Assumptions"]
 
 # Tone Dictionary Based on Content Creators
 TONE_DICTIONARY = {
@@ -30,13 +30,10 @@ TONE = TONE_DICTIONARY.get(CONTENT_CREATOR)
 # Optional example to be included
 EXAMPLE = "Baking cookies"
 
-
-# Function to construct the prompt with optional example
-def construct_prompt(base_prompt, topic):
-    prompt = f"{base_prompt} {topic} in a {TONE} tone."
-    if EXAMPLE:
-        prompt += f" Please include this example: {EXAMPLE}"
-    return prompt
+# Series Configuration
+IS_SERIES = True
+SERIES_TITLE = "ANOVA Explained"  # Title of the series
+SERIES_PART = ["Part 1", "Part 2", "Part 3"]  # Titles for each part of the series
 
 
 # Blog Post Structure with Conditional Example and Tone Included

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ def main():
     client.generate_and_save_blog_posts()
 
     # Generate and save video scripts
-    client.generate_and_save_video_scripts()
+    # client.generate_and_save_video_scripts()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
feat: Add series and standalone content generation with tone and example support

- Integrated `construct_prompt` method to include series information, tone, and examples in prompts.
- Updated `GPTClient` to handle both series and standalone content generation.
- Corrected the API call to `openai.chat.completions.create` for better compatibility.
- Added handling for saving content based on series parts or as standalone files.
- Ensured prompts are consistently formatted across all content generation methods.
 
- Need to update test before moving on